### PR TITLE
[CLOUDGA-28271] support to extract customer metadata in GCP

### DIFF
--- a/processor/resourcedetectionprocessor/internal/gcp/gcp.go
+++ b/processor/resourcedetectionprocessor/internal/gcp/gcp.go
@@ -5,6 +5,7 @@ package gcp // import "github.com/open-telemetry/opentelemetry-collector-contrib
 
 import (
 	"context"
+	"encoding/json"
 
 	"cloud.google.com/go/compute/metadata"
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp"
@@ -52,7 +53,20 @@ type detector struct {
 	rb       *localMetadata.ResourceBuilder
 }
 
-func (d *detector) Detect(context.Context) (resource pcommon.Resource, schemaURL string, err error) {
+// Extract all the custom metadata attributes from GCE instance metadata endpoint.
+func (d *detector) GCECustomMetadata(ctx context.Context) (map[string]interface{}, error) {
+	jsonStr, err := metadata.GetWithContext(ctx, "instance/attributes/?recursive=true&alt=json")
+	if err != nil {
+		return nil, err
+	}
+	var attrs map[string]interface{}
+	if err := json.Unmarshal([]byte(jsonStr), &attrs); err != nil {
+		return nil, err
+	}
+	return attrs, nil
+}
+
+func (d *detector) Detect(ctx context.Context) (resource pcommon.Resource, schemaURL string, err error) {
 	if d.detector.CloudPlatform() == gcp.BareMetalSolution {
 		d.rb.SetCloudProvider(conventions.CloudProviderGCP.Value.AsString())
 		errs := d.rb.SetFromCallable(d.rb.SetCloudAccountID, d.detector.BareMetalSolutionProjectID)
@@ -155,6 +169,11 @@ func (d *detector) Detect(context.Context) (resource pcommon.Resource, schemaURL
 			d.rb.SetFromCallable(d.rb.SetGcpGceInstanceName, d.detector.GCEInstanceName),
 			d.rb.SetManagedInstanceGroup(d.detector.GCEManagedInstanceGroup),
 		)
+		if attrs, err := d.GCECustomMetadata(ctx); err == nil {
+			d.rb.SetMyCustomMetadata(attrs)
+		} else {
+			d.logger.Warn("Failed to get GCE custom metadata", zap.Error(err))
+		}
 	default:
 		// We don't support this platform yet, so just return with what we have
 	}

--- a/processor/resourcedetectionprocessor/internal/gcp/internal/metadata/resource.go
+++ b/processor/resourcedetectionprocessor/internal/gcp/internal/metadata/resource.go
@@ -60,3 +60,15 @@ func (rb *ResourceBuilder) SetManagedInstanceGroup(detect func() (gcp.ManagedIns
 	}
 	return nil
 }
+
+// SetMyCustomMetadata inserts each custom metadata key/value as a resource attribute.
+func (rb *ResourceBuilder) SetMyCustomMetadata(attrs map[string]interface{}) error {
+	for k, v := range attrs {
+		if k == "startup-script" || k == "ssh-keys" {
+			continue // Ignore certain keys
+		}
+		key := "custom.metadata." + k // Prefix to avoid collisions
+		rb.res.Attributes().PutStr(key, fmt.Sprintf("%v", v))
+	}
+	return nil
+}


### PR DESCRIPTION
The current setup of [GitHub - open-telemetry/opentelemetry-collector-contrib: Contrib repository for the OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector-contrib)  does not support extracting GCE custom metadata.

Had opened a Q&A in their repo, but no response. [How to extract labels/custom metadata from a virtual machine in GCP · open-telemetry opentelemetry-collector-contrib · Discussion #40940](https://github.com/open-telemetry/opentelemetry-collector-contrib/discussions/40940) 

Reached out to them via slack community but still no ETA. https://cloud-native.slack.com/archives/C01N6P7KR6W/p1751011301242549Connect your Slack account

So patch the forked version to support the same.