### PR TITLE
[CLOUDGA-30463] Update shardfunction for shardprocessor

### DIFF
--- a/processor/shardprocessor/config_test.go
+++ b/processor/shardprocessor/config_test.go
@@ -4,7 +4,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/yugabyte/opentelemetry-collector-contrib/processor/shardprocessor/internal/metadata"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/shardprocessor/internal/metadata"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/otelcol/otelcoltest"

--- a/processor/shardprocessor/factory.go
+++ b/processor/shardprocessor/factory.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	"github.com/yugabyte/opentelemetry-collector-contrib/processor/shardprocessor/internal/metadata"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/shardprocessor/internal/metadata"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/processor"

--- a/processor/shardprocessor/go.mod
+++ b/processor/shardprocessor/go.mod
@@ -1,8 +1,9 @@
-module github.com/yugabyte/opentelemetry-collector-contrib/processor/shardprocessor
+module github.com/open-telemetry/opentelemetry-collector-contrib/processor/shardprocessor
 
 go 1.24.0
 
 require (
+	github.com/yugabyte/opentelemetry-collector-contrib/processor/shardprocessor v0.0.0-20251106114432-d36ed552ede3
 	go.opentelemetry.io/collector/component v1.45.0
 	go.opentelemetry.io/collector/consumer v1.45.0
 	go.opentelemetry.io/collector/consumer/consumertest v0.139.0

--- a/processor/shardprocessor/go.sum
+++ b/processor/shardprocessor/go.sum
@@ -114,6 +114,8 @@ github.com/tklauser/go-sysconf v0.3.15 h1:VE89k0criAymJ/Os65CSn1IXaol+1wrsFHEB8O
 github.com/tklauser/go-sysconf v0.3.15/go.mod h1:Dmjwr6tYFIseJw7a3dRLJfsHAMXZ3nEnL/aZY+0IuI4=
 github.com/tklauser/numcpus v0.10.0 h1:18njr6LDBk1zuna922MgdjQuJFjrdppsZG60sHGfjso=
 github.com/tklauser/numcpus v0.10.0/go.mod h1:BiTKazU708GQTYF4mB+cmlpT2Is1gLk7XVuEeem8LsQ=
+github.com/yugabyte/opentelemetry-collector-contrib/processor/shardprocessor v0.0.0-20251106114432-d36ed552ede3 h1:aIiIGhBTCGDdJyuH/YN3KemqI+ATlnuUyDL8tJmahYs=
+github.com/yugabyte/opentelemetry-collector-contrib/processor/shardprocessor v0.0.0-20251106114432-d36ed552ede3/go.mod h1:cegbyuFOieDLrpZnVN96WnJV3JphQRaBFCdksEUjSTM=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=

--- a/processor/shardprocessor/processor.go
+++ b/processor/shardprocessor/processor.go
@@ -2,8 +2,9 @@ package shardprocessor
 
 import (
 	"context"
+	"crypto/md5"
+	"encoding/binary"
 	"fmt"
-	"hash/fnv"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
@@ -126,7 +127,8 @@ func (sp *processorImp) applyShardToAttributes(attrs pcommon.Map) {
 }
 
 func (sp *processorImp) calculateShardID(name string) int {
-	hasher := fnv.New32a()
-	_, _ = hasher.Write([]byte(name))
-	return int(hasher.Sum32() % uint32(sp.config.NumShards))
+	// Prometheus hashmod: https://github.com/prometheus/prometheus/blob/d344ea7bf4cc9e9e131a0318d10025982e9c4cc1/model/relabel/relabel.go#L290-L294
+	sum := md5.Sum([]byte(name))
+	last8 := binary.BigEndian.Uint64(sum[8:])
+	return int(last8 % uint64(sp.config.NumShards))
 }

--- a/processor/shardprocessor/processor_test.go
+++ b/processor/shardprocessor/processor_test.go
@@ -129,3 +129,26 @@ func BenchmarkApplyShardToAttributes(b *testing.B) {
 		p.applyShardToAttributes(attrs)
 	}
 }
+
+func TestCalculateShardID_KnownUniverseUUIDs(t *testing.T) {
+	p := newProcessor(8, nil)
+
+	tests := []struct {
+		uuid     string
+		expected int
+	}{
+		{"0acc4e79-4dc7-4f05-b7d5-9b01f31b5aef", 1},
+		{"beac01ad-18e2-499b-b542-192dadce0f02", 2},
+		{"a46b68ca-413f-488b-bb51-8bd2a054f285", 4},
+		{"ed4c6b65-1c82-4024-944b-9fb6e7cb1959", 6},
+		{"c380ccbe-b613-4aef-a5e9-b03a243c5816", 5},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.uuid, func(t *testing.T) {
+			if got := p.calculateShardID(tt.uuid); got != tt.expected {
+				t.Fatalf("expected shard %d, got %d", tt.expected, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

This PR updates the shard function to use the prom hashmod md5 function


````
{shard_id="0", universe_uuid="5a22e142-1052-42d8-a3a4-94907498bbd6"} | 1
{shard_id="2", universe_uuid="648c8497-1995-46a9-93fc-2b19ef2d6ff5"} | 1
{shard_id="3", universe_uuid="ef17d1f7-bdfa-4675-9fbb-0bad0d4b365a"} | 1
{shard_id="1", universe_uuid="fdb3de0c-7264-4971-be54-223aef5d4258"} | 1
{shard_id="2", universe_uuid="138fb451-5eca-4f59-bb9a-6d9430e47c14"} | 1
{shard_id="0", universe_uuid="8980f487-b7d8-45a7-95a8-486cd0bcb486"} | 1
{shard_id="1", universe_uuid="f1db8755-5cd9-406d-8dfd-05ec937f0bc8"} | 1
{shard_id="2", universe_uuid="0a22602d-d905-4efd-a718-dddf113fadea"} | 1
{shard_id="0", universe_uuid="cd9366a5-d68e-4b50-8862-1465980acbe6"} | 1
 
 
{__tmp_hash="0", universe_uuid="5a22e142-1052-42d8-a3a4-94907498bbd6"} |  
{__tmp_hash="2", universe_uuid="648c8497-1995-46a9-93fc-2b19ef2d6ff5"} |  
{__tmp_hash="3", universe_uuid="ef17d1f7-bdfa-4675-9fbb-0bad0d4b365a"} |  
{__tmp_hash="1", universe_uuid="fdb3de0c-7264-4971-be54-223aef5d4258"} |  
{__tmp_hash="2", universe_uuid="138fb451-5eca-4f59-bb9a-6d9430e47c14"}
{__tmp_hash="0", universe_uuid="8980f487-b7d8-45a7-95a8-486cd0bcb486"}
{__tmp_hash="1", universe_uuid="f1db8755-5cd9-406d-8dfd-05ec937f0bc8"}
{__tmp_hash="2", universe_uuid="0a22602d-d905-4efd-a718-dddf113fadea"} |  
{__tmp_hash="0", universe_uuid="cd9366a5-d68e-4b50-8862-1465980acbe6"} |  

````


## Test Plan

````
➜  shardprocessor git:(mshasahnk/update-shard-function) go test ./... -v    
=== RUN   TestLoadConfig
--- PASS: TestLoadConfig (0.00s)
=== RUN   TestApplyShardToAttributes
=== RUN   TestApplyShardToAttributes/primary_label_takes_priority
=== RUN   TestApplyShardToAttributes/fallback_to_job_when_universe_uuid_missing
=== RUN   TestApplyShardToAttributes/default_shard_when_no_labels_match
--- PASS: TestApplyShardToAttributes (0.00s)
    --- PASS: TestApplyShardToAttributes/primary_label_takes_priority (0.00s)
    --- PASS: TestApplyShardToAttributes/fallback_to_job_when_universe_uuid_missing (0.00s)
    --- PASS: TestApplyShardToAttributes/default_shard_when_no_labels_match (0.00s)
=== RUN   TestConsumeMetrics_ShardsAppliedToDatapoints
--- PASS: TestConsumeMetrics_ShardsAppliedToDatapoints (0.00s)
=== RUN   TestCalculateShardID_Distribution
--- PASS: TestCalculateShardID_Distribution (0.00s)
=== RUN   TestCalculateShardID_Deterministic
=== RUN   TestCalculateShardID_Deterministic/abc
=== RUN   TestCalculateShardID_Deterministic/numbers
=== RUN   TestCalculateShardID_Deterministic/special
=== RUN   TestCalculateShardID_Deterministic/unicode
--- PASS: TestCalculateShardID_Deterministic (0.00s)
    --- PASS: TestCalculateShardID_Deterministic/abc (0.00s)
    --- PASS: TestCalculateShardID_Deterministic/numbers (0.00s)
    --- PASS: TestCalculateShardID_Deterministic/special (0.00s)
    --- PASS: TestCalculateShardID_Deterministic/unicode (0.00s)
=== RUN   TestCalculateShardID_InRange
--- PASS: TestCalculateShardID_InRange (0.00s)
=== RUN   TestCalculateShardID_Stable
--- PASS: TestCalculateShardID_Stable (0.00s)
PASS
ok      github.com/open-telemetry/opentelemetry-collector-contrib/processor/shardprocessor      0.013s
=== RUN   TestTypeValue
--- PASS: TestTypeValue (0.00s)
PASS
ok      github.com/open-telemetry/opentelemetry-collector-contrib/processor/shardprocessor/internal/metadata    0.005s
````